### PR TITLE
only Reader necessary, not ReadCloser

### DIFF
--- a/git_reader.go
+++ b/git_reader.go
@@ -8,8 +8,8 @@ import (
 
 // GitReader scans for errors in the output of a git command
 type GitReader struct {
-	// Underlaying reader (to relay calls to)
-	io.ReadCloser
+	// Underlying reader (to relay calls to)
+	io.Reader
 
 	// Error
 	GitError error
@@ -23,7 +23,7 @@ var (
 // Implement the io.Reader interface
 func (g *GitReader) Read(p []byte) (n int, err error) {
 	// Relay call
-	n, err = g.ReadCloser.Read(p)
+	n, err = g.Reader.Read(p)
 
 	// Scan for errors
 	g.scan(p)

--- a/githttp.go
+++ b/githttp.go
@@ -80,8 +80,8 @@ func (g *GitHttp) serviceRpc(hr HandlerReq) error {
 
 	// Reader that scans for events
 	rpcReader := &RpcReader{
-		ReadCloser: reader,
-		Rpc:        rpc,
+		Reader: reader,
+		Rpc:    rpc,
 	}
 
 	// Set content type
@@ -109,7 +109,7 @@ func (g *GitHttp) serviceRpc(hr HandlerReq) error {
 
 	// Scan's git command's output for errors
 	gitReader := &GitReader{
-		ReadCloser: stdout,
+		Reader: stdout,
 	}
 
 	// Copy input to git binary

--- a/rpc_reader.go
+++ b/rpc_reader.go
@@ -8,7 +8,7 @@ import (
 // RpcReader scans for events in the incoming rpc request data
 type RpcReader struct {
 	// Underlaying reader (to relay calls to)
-	io.ReadCloser
+	io.Reader
 
 	// Rpc type (upload-pack or receive-pack)
 	Rpc string
@@ -30,7 +30,7 @@ var (
 // Implement the io.Reader interface
 func (r *RpcReader) Read(p []byte) (n int, err error) {
 	// Relay call
-	n, err = r.ReadCloser.Read(p)
+	n, err = r.Reader.Read(p)
 
 	// Scan for events
 	if err != nil {


### PR DESCRIPTION
There's no reason to require an `io.ReadCloser` in RpcReader and GitReader. A `io.Reader` should suffice.

Also, thanks for making this great library!