### PR TITLE
Fix hang when --depth=1 is specified in clone

### DIFF
--- a/githttp.go
+++ b/githttp.go
@@ -95,7 +95,6 @@ func (g *GitHttp) serviceRpc(hr HandlerReq) error {
 	if err != nil {
 		return err
 	}
-	defer stdin.Close()
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -115,6 +114,7 @@ func (g *GitHttp) serviceRpc(hr HandlerReq) error {
 
 	// Copy input to git binary
 	io.Copy(stdin, rpcReader)
+	stdin.Close()
 
 	// Write git binary's output to http response
 	io.Copy(w, gitReader)
@@ -137,8 +137,9 @@ func (g *GitHttp) serviceRpc(hr HandlerReq) error {
 		g.event(e)
 	}
 
-	// May be nil if all is good
-	return mainError
+	// Because a response was already written,
+	// the header cannot be changed
+	return nil
 }
 
 func (g *GitHttp) getInfoRefs(hr HandlerReq) error {


### PR DESCRIPTION
Closes the input stream after the request is copied to it, otherwise the git command waits for the rest of the input and hangs.

Stops returning an error from serviceRpc. By the time the function returns a header and body have already been written to the output stream, so the response code cannot be changed. However, the additional error text in the body will confuse the git client.

Fixes https://github.com/AaronO/go-git-http/issues/22