### PR TITLE
Add support for custom repo resolvers

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -17,6 +17,9 @@ type AuthInfo struct {
 	// But could also be: "some_repo.git"
 	Repo string
 
+	// Request that needs to be authenticated in case you need access to additional headers or information about the request
+	Request *http.Request
+
 	// Are we pushing or fetching ?
 	Push  bool
 	Fetch bool
@@ -40,6 +43,7 @@ func Authenticator(authf func(AuthInfo) (bool, error)) func(http.Handler) http.H
 			info := AuthInfo{
 				Username: auth.Name,
 				Password: auth.Pass,
+				Request:  req,
 				Repo:     repoName(req.URL.Path),
 				Push:     isPush(req),
 				Fetch:    isFetch(req),

--- a/routing.go
+++ b/routing.go
@@ -90,7 +90,7 @@ func (g *GitHttp) requestHandler(w http.ResponseWriter, r *http.Request) {
 	file := strings.Replace(r.URL.Path, repo+"/", "", 1)
 
 	// Resolve directory
-	dir, err := g.getGitDir(repo)
+	dir, err := g.getGitDir(repo, r)
 
 	// Repo not found on disk
 	if err != nil {


### PR DESCRIPTION
We needed the ability to add custom resolver logic. Our resolvers also require information from the request such as the host from the request, and the resolve can be optimized to happen at the same time we check auth, so having access to the request in both auth and resolvers is very useful. This change does the following:

1) Add support for custom resolver (accepts path / request)
2) Add request to AuthInfo 